### PR TITLE
ci: update version strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
       - "RShirohara"
     reviewers:
       - "RShirohara"
+    versioning-strategy: increase
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/workflows/lint-package.yml
+++ b/.github/workflows/lint-package.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, ready_for_review, review_requested]
     paths:
       [
+        "yarn.lock",
         "**/package.json",
         "**/tsconfig.json",
         "packages/**/*.js",

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, ready_for_review, review_requested]
     paths:
       [
+        "yarn.lock",
         "**/package.json",
         "**/tsconfig.json",
         "packages/**/*.js",


### PR DESCRIPTION
- Update dependabot versioning strategy.
- Add `yarn.lock` file-changed trigger to lint and test action.