### PR TITLE
chore: bump package version

### DIFF
--- a/packages/pxast/CHANGELOG.md
+++ b/packages/pxast/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/pxast@0.1.5...@rshirohara/pxast@0.2.0) (2024-02-25)
+
+### ⚠ BREAKING CHANGES
+
+* definition of pxast content model stored in other phrasing content (#131)
+
+### Bug Fixes
+
+* definition of pxast content model stored in other phrasing content ([#131](https://github.com/RShirohara/unified-webnovel/issues/131)) ([4a84564](https://github.com/RShirohara/unified-webnovel/commit/4a84564eba310c24bc257738a6c0c2525e6545b4))
+
+### Code Refactoring
+
+* fix code reported by biome ([#244](https://github.com/RShirohara/unified-webnovel/issues/244)) ([59900d0](https://github.com/RShirohara/unified-webnovel/commit/59900d08e01e4d6ce25cdb5da2e5ab85b18e8129)), closes [#190](https://github.com/RShirohara/unified-webnovel/issues/190)
+
+### Build System
+
+* **deps:** bump @types/unist from 3.0.0 to 3.0.1 ([#174](https://github.com/RShirohara/unified-webnovel/issues/174)) ([dd6369c](https://github.com/RShirohara/unified-webnovel/commit/dd6369c85d61100afc0c1ec7a8f72ff42669ed11))
+* **deps:** bump @types/unist from 3.0.1 to 3.0.2 ([#185](https://github.com/RShirohara/unified-webnovel/issues/185)) ([fc02cef](https://github.com/RShirohara/unified-webnovel/commit/fc02cef92a702c7625029959a13c64735f9623e8))
+* use `*.ts` files with exports. ([#220](https://github.com/RShirohara/unified-webnovel/issues/220)) ([e1a4784](https://github.com/RShirohara/unified-webnovel/commit/e1a478402b68331636da1fc9c46cb9274004ba87)), closes [#191](https://github.com/RShirohara/unified-webnovel/issues/191)
+
 ## [0.1.5](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/pxast@0.1.4...@rshirohara/pxast@0.1.5) (2023-08-06)
 
 **Note:** Version bump only for package @rshirohara/pxast

--- a/packages/pxast/package.json
+++ b/packages/pxast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rshirohara/pxast",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Pixiv novel ast definition.",
   "keywords": [
     "unified",

--- a/packages/pxast/package.json
+++ b/packages/pxast/package.json
@@ -2,11 +2,7 @@
   "name": "@rshirohara/pxast",
   "version": "0.2.0",
   "description": "Pixiv novel ast definition.",
-  "keywords": [
-    "unified",
-    "repixe",
-    "pixiv"
-  ],
+  "keywords": ["unified", "repixe", "pixiv"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/pxast#readme",
   "bugs": {
     "url": "https://github.com/RShirohara/unified-webnovel/issues"
@@ -23,9 +19,7 @@
   },
   "main": "",
   "types": "./src/index.d.ts",
-  "files": [
-    "./src"
-  ],
+  "files": ["./src"],
   "scripts": {
     "prepack": "clean-package",
     "postpack": "clean-package restore"
@@ -41,11 +35,6 @@
     "provenance": true
   },
   "clean-package": {
-    "remove": [
-      "scripts",
-      "devDependencies",
-      "publishConfig",
-      "clean-package"
-    ]
+    "remove": ["scripts", "devDependencies", "publishConfig", "clean-package"]
   }
 }

--- a/packages/repixe-parse/CHANGELOG.md
+++ b/packages/repixe-parse/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.6](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-parse@0.1.5...@rshirohara/repixe-parse@0.1.6) (2024-02-25)
+
+### Code Refactoring
+
+* fix code reported by biome ([#244](https://github.com/RShirohara/unified-webnovel/issues/244)) ([59900d0](https://github.com/RShirohara/unified-webnovel/commit/59900d08e01e4d6ce25cdb5da2e5ab85b18e8129)), closes [#190](https://github.com/RShirohara/unified-webnovel/issues/190)
+
+### Build System
+
+* **deps:** bump unified from 10.1.2 to 11.0.2 ([#120](https://github.com/RShirohara/unified-webnovel/issues/120)) ([667a622](https://github.com/RShirohara/unified-webnovel/commit/667a622f090052bc3ba6242a35b353b2cb80bca9))
+* **deps:** bump unified from 11.0.2 to 11.0.3 ([#134](https://github.com/RShirohara/unified-webnovel/issues/134)) ([bca6c3c](https://github.com/RShirohara/unified-webnovel/commit/bca6c3c31fe473160d726a6e9f0c74fcc6526cc7))
+* **deps:** bump unified from 11.0.3 to 11.0.4 ([#179](https://github.com/RShirohara/unified-webnovel/issues/179)) ([47eb58f](https://github.com/RShirohara/unified-webnovel/commit/47eb58f337a54ba6a91e684ce7efbef173dd2e88))
+* drop Node.js v16 support ([#158](https://github.com/RShirohara/unified-webnovel/issues/158)) ([c1c87c8](https://github.com/RShirohara/unified-webnovel/commit/c1c87c89416c1a212e13d1b8efb494819e65a8f0))
+* use `*.ts` files with exports. ([#220](https://github.com/RShirohara/unified-webnovel/issues/220)) ([e1a4784](https://github.com/RShirohara/unified-webnovel/commit/e1a478402b68331636da1fc9c46cb9274004ba87)), closes [#191](https://github.com/RShirohara/unified-webnovel/issues/191)
+
 ## [0.1.5](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-parse@0.1.4...@rshirohara/repixe-parse@0.1.5) (2023-08-06)
 
 **Note:** Version bump only for package @rshirohara/repixe-parse

--- a/packages/repixe-parse/CHANGELOG.md
+++ b/packages/repixe-parse/CHANGELOG.md
@@ -3,7 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.1.6](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-parse@0.1.5...@rshirohara/repixe-parse@0.1.6) (2024-02-25)
+## [0.2.0](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-parse@0.1.5...@rshirohara/repixe-parse@0.2.0) (2024-02-25)
+
+### ⚠ BREAKING CHANGES
+
+* definition of pxast content model stored in other phrasing content (#131)
+* drop Node.js v16 support (#158)
 
 ### Code Refactoring
 

--- a/packages/repixe-parse/package.json
+++ b/packages/repixe-parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rshirohara/repixe-parse",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "repixe plugin to add support for parsing pixiv novel format.",
   "keywords": ["unified", "repixe", "repixe-plugin", "pixiv"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/repixe-parse#readme",

--- a/packages/repixe-parse/package.json
+++ b/packages/repixe-parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rshirohara/repixe-parse",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "repixe plugin to add support for parsing pixiv novel format.",
   "keywords": [
     "unified",
@@ -40,8 +40,8 @@
     "unified": "^11.0.4"
   },
   "devDependencies": {
-    "@unified-webnovel/tsconfig": "workspace:*",
-    "@types/pixiv-novel-parser": "workspace:*"
+    "@types/pixiv-novel-parser": "workspace:*",
+    "@unified-webnovel/tsconfig": "workspace:*"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/repixe-parse/package.json
+++ b/packages/repixe-parse/package.json
@@ -2,12 +2,7 @@
   "name": "@rshirohara/repixe-parse",
   "version": "0.1.6",
   "description": "repixe plugin to add support for parsing pixiv novel format.",
-  "keywords": [
-    "unified",
-    "repixe",
-    "repixe-plugin",
-    "pixiv"
-  ],
+  "keywords": ["unified", "repixe", "repixe-plugin", "pixiv"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/repixe-parse#readme",
   "bugs": {
     "url": "https://github.com/RShirohara/unified-webnovel/issues"
@@ -25,10 +20,7 @@
   "type": "module",
   "exports": "./src/index.ts",
   "types": "./src/index.ts",
-  "files": [
-    "./dist",
-    "./src"
-  ],
+  "files": ["./dist", "./src"],
   "scripts": {
     "build": "tsc -b tsconfig.build.json",
     "prepack": "pnpm run build && clean-package",
@@ -52,11 +44,6 @@
       "exports": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "remove": [
-      "scripts",
-      "devDependencies",
-      "publishConfig",
-      "clean-package"
-    ]
+    "remove": ["scripts", "devDependencies", "publishConfig", "clean-package"]
   }
 }

--- a/packages/repixe-stringify/CHANGELOG.md
+++ b/packages/repixe-stringify/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.6](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-stringify@0.1.5...@rshirohara/repixe-stringify@0.1.6) (2024-02-25)
+
+### Code Refactoring
+
+* fix code reported by biome ([#244](https://github.com/RShirohara/unified-webnovel/issues/244)) ([59900d0](https://github.com/RShirohara/unified-webnovel/commit/59900d08e01e4d6ce25cdb5da2e5ab85b18e8129)), closes [#190](https://github.com/RShirohara/unified-webnovel/issues/190)
+
+### Build System
+
+* **deps:** bump unified from 10.1.2 to 11.0.2 ([#120](https://github.com/RShirohara/unified-webnovel/issues/120)) ([667a622](https://github.com/RShirohara/unified-webnovel/commit/667a622f090052bc3ba6242a35b353b2cb80bca9))
+* **deps:** bump unified from 11.0.2 to 11.0.3 ([#134](https://github.com/RShirohara/unified-webnovel/issues/134)) ([bca6c3c](https://github.com/RShirohara/unified-webnovel/commit/bca6c3c31fe473160d726a6e9f0c74fcc6526cc7))
+* **deps:** bump unified from 11.0.3 to 11.0.4 ([#179](https://github.com/RShirohara/unified-webnovel/issues/179)) ([47eb58f](https://github.com/RShirohara/unified-webnovel/commit/47eb58f337a54ba6a91e684ce7efbef173dd2e88))
+* drop Node.js v16 support ([#158](https://github.com/RShirohara/unified-webnovel/issues/158)) ([c1c87c8](https://github.com/RShirohara/unified-webnovel/commit/c1c87c89416c1a212e13d1b8efb494819e65a8f0))
+* use `*.ts` files with exports. ([#220](https://github.com/RShirohara/unified-webnovel/issues/220)) ([e1a4784](https://github.com/RShirohara/unified-webnovel/commit/e1a478402b68331636da1fc9c46cb9274004ba87)), closes [#191](https://github.com/RShirohara/unified-webnovel/issues/191)
+
 ## [0.1.5](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-stringify@0.1.4...@rshirohara/repixe-stringify@0.1.5) (2023-08-06)
 
 **Note:** Version bump only for package @rshirohara/repixe-stringify

--- a/packages/repixe-stringify/CHANGELOG.md
+++ b/packages/repixe-stringify/CHANGELOG.md
@@ -3,7 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.1.6](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-stringify@0.1.5...@rshirohara/repixe-stringify@0.1.6) (2024-02-25)
+## [0.2.0](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-stringify@0.1.5...@rshirohara/repixe-stringify@0.2.0) (2024-02-25)
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js v16 support (#158)
 
 ### Code Refactoring
 

--- a/packages/repixe-stringify/package.json
+++ b/packages/repixe-stringify/package.json
@@ -2,12 +2,7 @@
   "name": "@rshirohara/repixe-stringify",
   "version": "0.1.6",
   "description": "repixe plugin to add support for serializing pixiv novel format.",
-  "keywords": [
-    "unified",
-    "repixe",
-    "repixe-plugin",
-    "pixiv"
-  ],
+  "keywords": ["unified", "repixe", "repixe-plugin", "pixiv"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/repixe-stringify#readme",
   "bugs": {
     "url": "https://github.com/RShirohara/unified-webnovel/issues"
@@ -25,10 +20,7 @@
   "type": "module",
   "exports": "./src/index.ts",
   "types": "./src/index.ts",
-  "files": [
-    "./dist",
-    "./src"
-  ],
+  "files": ["./dist", "./src"],
   "scripts": {
     "build": "tsc -b tsconfig.build.json",
     "prepack": "pnpm run build && clean-package",
@@ -50,11 +42,6 @@
       "exports": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "remove": [
-      "scripts",
-      "devDependencies",
-      "publishConfig",
-      "clean-package"
-    ]
+    "remove": ["scripts", "devDependencies", "publishConfig", "clean-package"]
   }
 }

--- a/packages/repixe-stringify/package.json
+++ b/packages/repixe-stringify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rshirohara/repixe-stringify",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "repixe plugin to add support for serializing pixiv novel format.",
   "keywords": [
     "unified",

--- a/packages/repixe-stringify/package.json
+++ b/packages/repixe-stringify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rshirohara/repixe-stringify",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "repixe plugin to add support for serializing pixiv novel format.",
   "keywords": ["unified", "repixe", "repixe-plugin", "pixiv"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/repixe-stringify#readme",

--- a/packages/repixe/CHANGELOG.md
+++ b/packages/repixe/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.1](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe@0.1.0...@rshirohara/repixe@0.1.1) (2024-02-25)
+
+### Code Refactoring
+
+* fix code reported by biome ([#244](https://github.com/RShirohara/unified-webnovel/issues/244)) ([59900d0](https://github.com/RShirohara/unified-webnovel/commit/59900d08e01e4d6ce25cdb5da2e5ab85b18e8129)), closes [#190](https://github.com/RShirohara/unified-webnovel/issues/190)
+
+### Build System
+
+* **deps:** bump unified from 10.1.2 to 11.0.2 ([#120](https://github.com/RShirohara/unified-webnovel/issues/120)) ([667a622](https://github.com/RShirohara/unified-webnovel/commit/667a622f090052bc3ba6242a35b353b2cb80bca9))
+* **deps:** bump unified from 11.0.2 to 11.0.3 ([#134](https://github.com/RShirohara/unified-webnovel/issues/134)) ([bca6c3c](https://github.com/RShirohara/unified-webnovel/commit/bca6c3c31fe473160d726a6e9f0c74fcc6526cc7))
+* **deps:** bump unified from 11.0.3 to 11.0.4 ([#179](https://github.com/RShirohara/unified-webnovel/issues/179)) ([47eb58f](https://github.com/RShirohara/unified-webnovel/commit/47eb58f337a54ba6a91e684ce7efbef173dd2e88))
+* drop Node.js v16 support ([#158](https://github.com/RShirohara/unified-webnovel/issues/158)) ([c1c87c8](https://github.com/RShirohara/unified-webnovel/commit/c1c87c89416c1a212e13d1b8efb494819e65a8f0))
+* use `*.ts` files with exports. ([#220](https://github.com/RShirohara/unified-webnovel/issues/220)) ([e1a4784](https://github.com/RShirohara/unified-webnovel/commit/e1a478402b68331636da1fc9c46cb9274004ba87)), closes [#191](https://github.com/RShirohara/unified-webnovel/issues/191)
+
 ## 0.1.0 (2023-08-06)
 
 ### Features

--- a/packages/repixe/CHANGELOG.md
+++ b/packages/repixe/CHANGELOG.md
@@ -3,7 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.1.1](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe@0.1.0...@rshirohara/repixe@0.1.1) (2024-02-25)
+## [0.2.0](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe@0.1.0...@rshirohara/repixe@0.2.0) (2024-02-25)
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js v16 support (#158)
 
 ### Code Refactoring
 

--- a/packages/repixe/package.json
+++ b/packages/repixe/package.json
@@ -2,11 +2,7 @@
   "name": "@rshirohara/repixe",
   "version": "0.1.1",
   "description": "unified processor with support for parsing and serializing pixiv novel format input/output.",
-  "keywords": [
-    "unified",
-    "repixe",
-    "pixiv"
-  ],
+  "keywords": ["unified", "repixe", "pixiv"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/repixe#readme",
   "bugs": {
     "url": "https://github.com/RShirohara/unified-webnovel/issues"
@@ -24,10 +20,7 @@
   "type": "module",
   "exports": "./src/index.ts",
   "types": "./src/index.ts",
-  "files": [
-    "./dist",
-    "./src"
-  ],
+  "files": ["./dist", "./src"],
   "scripts": {
     "build": "tsc -b tsconfig.build.json",
     "prepack": "pnpm run build && clean-package",
@@ -52,11 +45,6 @@
       "exports": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "remove": [
-      "scripts",
-      "devDependencies",
-      "publishConfig",
-      "clean-package"
-    ]
+    "remove": ["scripts", "devDependencies", "publishConfig", "clean-package"]
   }
 }

--- a/packages/repixe/package.json
+++ b/packages/repixe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rshirohara/repixe",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "unified processor with support for parsing and serializing pixiv novel format input/output.",
   "keywords": [
     "unified",

--- a/packages/repixe/package.json
+++ b/packages/repixe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rshirohara/repixe",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "unified processor with support for parsing and serializing pixiv novel format input/output.",
   "keywords": ["unified", "repixe", "pixiv"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/repixe#readme",


### PR DESCRIPTION
## description

Bump package version:

- `@rshirohara/pxast`: from `v0.1.5` to `v0.2.0`
- `@rshirohara/repixe-parse`: from `v0.1.5` to `v0.1.6`
- `@rshirohara/repixe-stringify`: from `v0.1.5` to `v0.1.6`
- `@rshirohara/repixe`: from `v0.1.0` to `v0.1.1`