### PR TITLE
ci: maintenance for GitHub Actions

### DIFF
--- a/.github/actions/setup-pnpm/action.yaml
+++ b/.github/actions/setup-pnpm/action.yaml
@@ -17,7 +17,7 @@ runs:
 
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v2.4.0
+      uses: pnpm/action-setup@v3.0.0
       with:
         run_install: false
 

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,8 +5,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "saturday"
+      interval: "monthly"
       time: "03:00"
       timezone: "Asia/Tokyo"
     labels:
@@ -30,8 +29,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "saturday"
+      interval: "monthly"
       time: "03:00"
       timezone: "Asia/Tokyo"
     labels:

--- a/.github/workflows/ci-action.yaml
+++ b/.github/workflows/ci-action.yaml
@@ -2,7 +2,7 @@ name: CI (GitHub Actions)
 
 on:
   pull_request:
-    types: [opened, ready_for_review, review_requested]
+    types: [ready_for_review, review_requested]
     paths: [".github/**/*.yaml"]
   push:
     branches: [main]

--- a/.github/workflows/ci-package.yaml
+++ b/.github/workflows/ci-package.yaml
@@ -2,15 +2,15 @@ name: CI (Node.js package)
 
 on:
   pull_request:
-    types: [opened, ready_for_review, review_requested]
+    types: [ready_for_review, review_requested]
     paths:
       [
         ".github/workflows/ci-package.yaml",
         "**/package.json",
         "**/tsconfig.json",
+        "biome.json",
         "packages/**/*.js",
         "packages/**/*.ts",
-        "eslint.config.js",
         "pnpm-lock.yaml"
       ]
   push:

--- a/.github/workflows/ci-package.yaml
+++ b/.github/workflows/ci-package.yaml
@@ -1,4 +1,4 @@
-name: CI (Node.js package)
+name: CI (npm package)
 
 on:
   pull_request:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["javascript"]
+        language: ["javascript-typescript"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'swift' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
         # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -4,15 +4,15 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    types: [opened, ready_for_review, review_requested]
+    types: [ready_for_review, review_requested]
     paths:
       [
-        "pnpm-lock.yaml",
+        ".github/workflows/codeql.yaml",
         "**/package.json",
         "**/tsconfig.json",
         "packages/**/*.js",
         "packages/**/*.ts",
-        ".github/workflows/codeql.yaml"
+        "pnpm-lock.yaml"
       ]
   schedule:
     - cron: "31 13 * * 5"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![LICENSE][license-badge]][license]
 [![Release and Publish](https://github.com/RShirohara/unified-webnovel/actions/workflows/release.yaml/badge.svg?branch=main)](https://github.com/RShirohara/unified-webnovel/actions/workflows/release.yaml)
-[![CI (Node.js package)](https://github.com/RShirohara/unified-webnovel/actions/workflows/ci-package.yaml/badge.svg?branch=main)](https://github.com/RShirohara/unified-webnovel/actions/workflows/ci-package.yaml)
+[![CI (npm package)](https://github.com/RShirohara/unified-webnovel/actions/workflows/ci-package.yaml/badge.svg?branch=main)](https://github.com/RShirohara/unified-webnovel/actions/workflows/ci-package.yaml)
 
 [unified][] packages for web novel.
 


### PR DESCRIPTION
## Desciption

- Bump action `pnpm/action-setup` from `v2.4.0` to `v3.0.0`.
- Change schedule for dependabot update check.
- Change action trigger on `pull_request`.
- Change action name for `ci-package`.