### PR TITLE
test: change default environment to `edge-runtime`

### DIFF
--- a/.github/workflows/ci-package.yaml
+++ b/.github/workflows/ci-package.yaml
@@ -66,7 +66,7 @@ jobs:
           reporter: github-check
 
   test:
-    name: Test (nodejs-${{ matrix.node-version }} on ${{ matrix.os }})
+    name: Test (${{ matrix.label }})
     runs-on: ${{ matrix.os }}
     needs: build
 
@@ -74,7 +74,19 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: [18, 20, latest]
+        include:
+          - label: edge-runtime
+            node-version: latest
+            test-environment: edge-runtime
+          - label: nodejs-latest
+            node-version: latest
+            test-environment: node
+          - label: nodejs-20
+            node-version: 20
+            test-environment: node
+          - label: nodejs-18
+            node-version: 18
+            test-environment: node
 
     permissions:
       checks: write
@@ -96,20 +108,21 @@ jobs:
       - name: Run test
         run: |
           pnpm run test \
-            --reporter basic \
-            --reporter junit \
-            --outputFile ./result.xml \
+            --environment=${{ matrix.test-environment }} \
+            --reporter=basic \
+            --reporter=junit \
+            --outputFile=./result.xml \
             --silent
 
       - name: Report test result
         if: ${{ (success() || failure()) }}
         uses: mikepenz/action-junit-report@v4.1.0
         with:
-          check_name: Test result (nodejs-${{ matrix.node-version }} on ${{ matrix.os }})
+          check_name: Test result (${{ matrix.label }})
           report_paths: ./result.xml
 
       - name: Report test coverage
-        if: ${{ (success() || failure()) && (github.event_name == 'pull_request') && (matrix.os == 'ubuntu-latest') && (matrix.node-version == 'latest') }}
+        if: ${{ (success() || failure()) && (github.event_name == 'pull_request') && (matrix.os == 'ubuntu-latest') && (matrix.label == 'edge-runtime') }}
         uses: davelosert/vitest-coverage-report-action@v2.2.1
         with:
           vite-config-path: ./vitest.workspace.js

--- a/.github/workflows/ci-package.yaml
+++ b/.github/workflows/ci-package.yaml
@@ -74,7 +74,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: [18, 20, latest]
+        label: [
+          edge-runtime,
+          nodejs-latest,
+          nodejs-20,
+          nodejs-18
+        ]
         include:
           - label: edge-runtime
             node-version: latest

--- a/.github/workflows/ci-package.yaml
+++ b/.github/workflows/ci-package.yaml
@@ -74,6 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        node-version: [18, 20, latest]
         include:
           - label: edge-runtime
             node-version: latest

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "license": "MIT",
   "type": "module",
   "packageManager": "pnpm@8.15.3",
-  "workspaces": ["./packages/*"],
+  "workspaces": [
+    "./packages/*"
+  ],
   "scripts": {
     "build": "pnpm run -r build",
     "check": "biome check .",
@@ -17,6 +19,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.5.3",
+    "@edge-runtime/vm": "^3.2.0",
     "@lerna-lite/changed": "^3.3.0",
     "@lerna-lite/cli": "^3.3.0",
     "@lerna-lite/publish": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "license": "MIT",
   "type": "module",
   "packageManager": "pnpm@8.15.3",
-  "workspaces": [
-    "./packages/*"
-  ],
+  "workspaces": ["./packages/*"],
   "scripts": {
     "build": "pnpm run -r build",
     "check": "biome check .",

--- a/packages/repixe-parse/test/pxast.test.ts
+++ b/packages/repixe-parse/test/pxast.test.ts
@@ -1,6 +1,6 @@
 import type { Root } from "@rshirohara/pxast";
 import { describe, expect, test } from "vitest";
-import { fromPixivNovel } from "~/lib";
+import { fromPixivNovel } from "~/lib/index.js";
 
 describe("FlowContent", () => {
   describe("Heading", () => {

--- a/packages/repixe-parse/test/transformer.test.ts
+++ b/packages/repixe-parse/test/transformer.test.ts
@@ -1,7 +1,7 @@
 import type { Root } from "@rshirohara/pxast";
 import { Parser } from "pixiv-novel-parser";
 import { describe, expect, test } from "vitest";
-import { fromPixivNovel } from "~/lib";
+import { fromPixivNovel } from "~/lib/index.js";
 
 describe("Text", () => {
   test("改行を持たない場合はそのまま追加される", () => {

--- a/packages/repixe-parse/test/tsconfig.json
+++ b/packages/repixe-parse/test/tsconfig.json
@@ -1,6 +1,0 @@
-{
-  "extends": [
-    "../tsconfig.json",
-    "@unified-webnovel/tsconfig/tsconfig.test.json"
-  ]
-}

--- a/packages/repixe-parse/test/unified.test.ts
+++ b/packages/repixe-parse/test/unified.test.ts
@@ -1,7 +1,7 @@
 import type { Root } from "@rshirohara/pxast";
 import { unified } from "unified";
 import { expect, test } from "vitest";
-import { repixeParse } from "~/index";
+import { repixeParse } from "~/index.js";
 
 test("repixeParse", () => {
   const source = [

--- a/packages/repixe-parse/vitest.config.js
+++ b/packages/repixe-parse/vitest.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     name: "repixe-parse",
     include: ["./test/**/*.test.ts"],
-    environment: "node",
+    environment: "edge-runtime",
     alias: {
       "~/": new URL("./src/", import.meta.url).pathname,
     },

--- a/packages/repixe-stringify/test/pxast.test.ts
+++ b/packages/repixe-stringify/test/pxast.test.ts
@@ -1,6 +1,6 @@
 import type { Root } from "@rshirohara/pxast";
 import { describe, expect, test } from "vitest";
-import { toPixivNovel } from "~/lib";
+import { toPixivNovel } from "~/lib/index.js";
 
 describe("Root", () => {
   test("複数の子要素は '\\n\\n' で結合される", () => {

--- a/packages/repixe-stringify/test/tsconfig.json
+++ b/packages/repixe-stringify/test/tsconfig.json
@@ -1,6 +1,0 @@
-{
-  "extends": [
-    "../tsconfig.json",
-    "@unified-webnovel/tsconfig/tsconfig.test.json"
-  ]
-}

--- a/packages/repixe-stringify/test/unified.test.ts
+++ b/packages/repixe-stringify/test/unified.test.ts
@@ -1,7 +1,7 @@
 import type { Root } from "@rshirohara/pxast";
 import { unified } from "unified";
 import { expect, test } from "vitest";
-import { repixeStringify } from "~/index";
+import { repixeStringify } from "~/index.js";
 
 test("repixeStringify", () => {
   const source: Root = {

--- a/packages/repixe-stringify/vitest.config.js
+++ b/packages/repixe-stringify/vitest.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     name: "repixe-stringify",
     include: ["./test/**/*.test.ts"],
-    environment: "node",
+    environment: "edge-runtime",
     alias: {
       "~/": new URL("./src/", import.meta.url).pathname,
     },

--- a/packages/repixe/test/tsconfig.json
+++ b/packages/repixe/test/tsconfig.json
@@ -1,6 +1,0 @@
-{
-  "extends": [
-    "../tsconfig.json",
-    "@unified-webnovel/tsconfig/tsconfig.test.json"
-  ]
-}

--- a/packages/repixe/test/unified.test.ts
+++ b/packages/repixe/test/unified.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { repixe } from "~/index";
+import { repixe } from "~/index.js";
 
 test("repixe", async () => {
   const source = [

--- a/packages/repixe/vitest.config.js
+++ b/packages/repixe/vitest.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     name: "repixe",
     include: ["./test/**/*.test.ts"],
-    environment: "node",
+    environment: "edge-runtime",
     alias: {
       "~/": new URL("./src/", import.meta.url).pathname,
     },

--- a/packages/tsconfig/tsconfig.test.json
+++ b/packages/tsconfig/tsconfig.test.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.base.json",
-  "compilerOptions": {
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "types": ["vitest/globals"]
-  }
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@biomejs/biome':
         specifier: ^1.5.3
         version: 1.5.3
+      '@edge-runtime/vm':
+        specifier: ^3.2.0
+        version: 3.2.0
       '@lerna-lite/changed':
         specifier: ^3.3.0
         version: 3.3.0(@lerna-lite/publish@3.3.0)(@lerna-lite/version@3.3.0)(typescript@5.3.3)
@@ -40,7 +43,7 @@ importers:
         version: 4.3.1(typescript@5.3.3)
       vitest:
         specifier: ^1.3.1
-        version: 1.3.1
+        version: 1.3.1(@edge-runtime/vm@3.2.0)
 
   packages/kkast:
     dependencies:
@@ -273,6 +276,18 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@edge-runtime/primitives@4.1.0:
+    resolution: {integrity: sha512-Vw0lbJ2lvRUqc7/soqygUX216Xb8T3WBZ987oywz6aJqRxcwSVWwr9e+Nqo2m9bxobA9mdbWNNoRY6S9eko1EQ==}
+    engines: {node: '>=16'}
+    dev: true
+
+  /@edge-runtime/vm@3.2.0:
+    resolution: {integrity: sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@edge-runtime/primitives': 4.1.0
+    dev: true
 
   /@esbuild/aix-ppc64@0.19.12:
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -1310,7 +1325,7 @@ packages:
       std-env: 3.7.0
       test-exclude: 6.0.0
       v8-to-istanbul: 9.2.0
-      vitest: 1.3.1
+      vitest: 1.3.1(@edge-runtime/vm@3.2.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4240,7 +4255,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.3.1:
+  /vitest@1.3.1(@edge-runtime/vm@3.2.0):
     resolution: {integrity: sha512-/1QJqXs8YbCrfv/GPQ05wAZf2eakUPLPa18vkJAKE7RXOKfVHqMZZ1WlTjiwl6Gcn65M5vpNUB6EFLnEdRdEXQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -4265,6 +4280,7 @@ packages:
       jsdom:
         optional: true
     dependencies:
+      '@edge-runtime/vm': 3.2.0
       '@vitest/expect': 1.3.1
       '@vitest/runner': 1.3.1
       '@vitest/snapshot': 1.3.1


### PR DESCRIPTION
## Description

- Change default test environment from `node` to `edge-runtime`.
- Change test environment matrix on CI.
- Fix module resolution problem in test.