### PR TITLE
build: remove items related to local development environment from `package.json`

### DIFF
--- a/packages/kkast/package.json
+++ b/packages/kkast/package.json
@@ -35,6 +35,10 @@
     "provenance": true
   },
   "clean-package": {
-    "remove": ["devDependencies", "publishConfig", "clean-package"]
+    "remove": [
+      "devDependencies.@unified-webnovel/tsconfig",
+      "publishConfig",
+      "clean-package"
+    ]
   }
 }

--- a/packages/pxast/package.json
+++ b/packages/pxast/package.json
@@ -35,6 +35,10 @@
     "provenance": true
   },
   "clean-package": {
-    "remove": ["devDependencies", "publishConfig", "clean-package"]
+    "remove": [
+      "devDependencies.@unified-webnovel/tsconfig",
+      "publishConfig",
+      "clean-package"
+    ]
   }
 }

--- a/packages/rekurke-parse/package.json
+++ b/packages/rekurke-parse/package.json
@@ -46,6 +46,13 @@
       "exports": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "remove": ["devDependencies", "publishConfig", "clean-package"]
+    "remove": [
+      "scripts.build",
+      "scripts.build:peg",
+      "scripts.build:ts",
+      "devDependencies.@unified-webnovel/tsconfig",
+      "publishConfig",
+      "clean-package"
+    ]
   }
 }

--- a/packages/repixe-parse/package.json
+++ b/packages/repixe-parse/package.json
@@ -44,6 +44,12 @@
       "exports": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "remove": ["devDependencies", "publishConfig", "clean-package"]
+    "remove": [
+      "scripts.build",
+      "devDependencies.@types/pixiv-novel-parser",
+      "devDependencies.@unified-webnovel/tsconfig",
+      "publishConfig",
+      "clean-package"
+    ]
   }
 }

--- a/packages/repixe-stringify/package.json
+++ b/packages/repixe-stringify/package.json
@@ -42,6 +42,11 @@
       "exports": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "remove": ["devDependencies", "publishConfig", "clean-package"]
+    "remove": [
+      "scripts.build",
+      "devDependencies.@unified-webnovel/tsconfig",
+      "publishConfig",
+      "clean-package"
+    ]
   }
 }

--- a/packages/repixe/package.json
+++ b/packages/repixe/package.json
@@ -45,6 +45,12 @@
       "exports": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "remove": ["devDependencies", "publishConfig", "clean-package"]
+    "remove": [
+      "scripts.build",
+      "devDependencies.@types/pixiv-novel-parser",
+      "devDependencies.@unified-webnovel/tsconfig",
+      "publishConfig",
+      "clean-package"
+    ]
   }
 }


### PR DESCRIPTION
Remove the following sections from `package.json` at build time that are used only in the local development environment.

- `scripts.build*`
- `devDependencies.@types/pixiv-novel-parser`
- `devDependencies.@unified-webnovel/tsconfig`
