### PR TITLE
docs: fix package description and keyword

### DIFF
--- a/packages/rekurke-stringify/package.json
+++ b/packages/rekurke-stringify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rshirohara/rekurke-stringify",
   "version": "0.1.0",
-  "description": "repixe plugin to add support for serializing kakuyomu novel format.",
+  "description": "rekurke plugin to add support for serializing kakuyomu novel format.",
   "keywords": ["unified", "rekurke", "kakuyomu"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/rekurke-stringify#readme",
   "bugs": {

--- a/packages/repixe-parse/package.json
+++ b/packages/repixe-parse/package.json
@@ -2,7 +2,7 @@
   "name": "@rshirohara/repixe-parse",
   "version": "0.2.2",
   "description": "repixe plugin to add support for parsing pixiv novel format.",
-  "keywords": ["unified", "repixe", "repixe-plugin", "pixiv"],
+  "keywords": ["unified", "repixe", "pixiv"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/repixe-parse#readme",
   "bugs": {
     "url": "https://github.com/RShirohara/unified-webnovel/issues"

--- a/packages/repixe-stringify/package.json
+++ b/packages/repixe-stringify/package.json
@@ -2,7 +2,7 @@
   "name": "@rshirohara/repixe-stringify",
   "version": "0.2.2",
   "description": "repixe plugin to add support for serializing pixiv novel format.",
-  "keywords": ["unified", "repixe", "repixe-plugin", "pixiv"],
+  "keywords": ["unified", "repixe", "pixiv"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/repixe-stringify#readme",
   "bugs": {
     "url": "https://github.com/RShirohara/unified-webnovel/issues"


### PR DESCRIPTION
- Fix typo in package description.
- Unify keyword for `repixe` packages.