### PR TITLE
chore: bump version

### DIFF
--- a/packages/kkast/CHANGELOG.md
+++ b/packages/kkast/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.2](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/kkast@0.1.1...@rshirohara/kkast@0.1.2) (2024-09-08)
+
+* build(deps): bump @types/unist from 3.0.2 to 3.0.3 (#321) ([c16c922](https://github.com/RShirohara/unified-webnovel/commit/c16c922)), closes [#321](https://github.com/RShirohara/unified-webnovel/issues/321)
+
 ## [0.1.1](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/kkast@0.1.0...@rshirohara/kkast@0.1.1) (2024-04-09)
 
 ### Documents

--- a/packages/kkast/package.json
+++ b/packages/kkast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rshirohara/kkast",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Kakuyomu novel ast definition.",
   "keywords": ["unified", "rekurke", "kakuyomu"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/kkast#readme",

--- a/packages/pxast/CHANGELOG.md
+++ b/packages/pxast/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.3](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/pxast@0.2.2...@rshirohara/pxast@0.2.3) (2024-09-08)
+
+* build(deps): bump @types/unist from 3.0.2 to 3.0.3 (#321) ([c16c922](https://github.com/RShirohara/unified-webnovel/commit/c16c922)), closes [#321](https://github.com/RShirohara/unified-webnovel/issues/321)
+
 ## [0.2.2](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/pxast@0.2.1...@rshirohara/pxast@0.2.2) (2024-04-09)
 
 ### Documents

--- a/packages/pxast/package.json
+++ b/packages/pxast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rshirohara/pxast",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Pixiv novel ast definition.",
   "keywords": ["unified", "repixe", "pixiv"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/pxast#readme",

--- a/packages/rekurke-parse/CHANGELOG.md
+++ b/packages/rekurke-parse/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.1](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke-parse@0.1.0...@rshirohara/rekurke-parse@0.1.1) (2024-09-08)
+
+* build(deps-dev): bump peggy from 4.0.2 to 4.0.3 in the peggy group (#306) ([9282ff0](https://github.com/RShirohara/unified-webnovel/commit/9282ff0)), closes [#306](https://github.com/RShirohara/unified-webnovel/issues/306)
+* build(deps): bump unified from 11.0.4 to 11.0.5 (#308) ([2c675ee](https://github.com/RShirohara/unified-webnovel/commit/2c675ee)), closes [#308](https://github.com/RShirohara/unified-webnovel/issues/308)
+
 ## 0.1.0 (2024-04-09)
 
 ### Features

--- a/packages/rekurke-parse/package.json
+++ b/packages/rekurke-parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rshirohara/rekurke-parse",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "rekurke plugin to add support for parsing kakuyomu novel format.",
   "keywords": ["unified", "rekurke", "kakuyomu"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/rekurke-parse#readme",

--- a/packages/rekurke-repixe/CHANGELOG.md
+++ b/packages/rekurke-repixe/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.1.0 (2024-09-08)
+
+* feat: add package `rekurke-repixe` (#327) ([b3cb450](https://github.com/RShirohara/unified-webnovel/commit/b3cb450)), closes [#327](https://github.com/RShirohara/unified-webnovel/issues/327)

--- a/packages/rekurke-repixe/package.json
+++ b/packages/rekurke-repixe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rshirohara/rekurke-repixe",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0",
   "description": "rekurke plugin that turns kakuyomu novel format into pixiv novel format to support repixe.",
   "keywords": ["unified", "rekurke", "kakuyomu", "repixe", "pixiv"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/rekurke-repixe#readme",
@@ -33,9 +33,9 @@
     "vfile": "^6.0.3"
   },
   "devDependencies": {
-    "@rshirohara/repixe-stringify": "workspace:*",
     "@rshirohara/rekurke-parse": "workspace:*",
     "@rshirohara/rekurke-stringify": "workspace:*",
+    "@rshirohara/repixe-stringify": "workspace:*",
     "@unified-webnovel/tsconfig": "workspace:*"
   },
   "publishConfig": {

--- a/packages/rekurke-stringify/CHANGELOG.md
+++ b/packages/rekurke-stringify/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.2](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke-stringify@0.1.1...@rshirohara/rekurke-stringify@0.1.2) (2024-09-08)
+
+* build(deps): bump unified from 11.0.4 to 11.0.5 (#308) ([2c675ee](https://github.com/RShirohara/unified-webnovel/commit/2c675ee)), closes [#308](https://github.com/RShirohara/unified-webnovel/issues/308)
+
 ## [0.1.1](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke-stringify@0.1.0...@rshirohara/rekurke-stringify@0.1.1) (2024-04-14)
 
 ### Documents

--- a/packages/rekurke-stringify/package.json
+++ b/packages/rekurke-stringify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rshirohara/rekurke-stringify",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "rekurke plugin to add support for serializing kakuyomu novel format.",
   "keywords": ["unified", "rekurke", "kakuyomu"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/rekurke-stringify#readme",

--- a/packages/rekurke/CHANGELOG.md
+++ b/packages/rekurke/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.2](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke@0.1.1...@rshirohara/rekurke@0.1.2) (2024-09-08)
+
+* build(deps): bump unified from 11.0.4 to 11.0.5 (#308) ([2c675ee](https://github.com/RShirohara/unified-webnovel/commit/2c675ee)), closes [#308](https://github.com/RShirohara/unified-webnovel/issues/308)
+
 ## [0.1.1](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke@0.1.0...@rshirohara/rekurke@0.1.1) (2024-04-14)
 
 **Note:** Version bump only for package @rshirohara/rekurke

--- a/packages/rekurke/package.json
+++ b/packages/rekurke/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rshirohara/rekurke",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "unified processor with support for parsing and serializing kakuyomu novel format input/output.",
   "keywords": ["unified", "rekurke", "kakuyomu"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/rekurke#readme",

--- a/packages/repixe-parse/CHANGELOG.md
+++ b/packages/repixe-parse/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.4](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-parse@0.2.3...@rshirohara/repixe-parse@0.2.4) (2024-09-08)
+
+* build(deps): bump unified from 11.0.4 to 11.0.5 (#308) ([2c675ee](https://github.com/RShirohara/unified-webnovel/commit/2c675ee)), closes [#308](https://github.com/RShirohara/unified-webnovel/issues/308)
+
 ## [0.2.3](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-parse@0.2.2...@rshirohara/repixe-parse@0.2.3) (2024-04-14)
 
 ### Documents

--- a/packages/repixe-parse/package.json
+++ b/packages/repixe-parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rshirohara/repixe-parse",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "repixe plugin to add support for parsing pixiv novel format.",
   "keywords": ["unified", "repixe", "pixiv"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/repixe-parse#readme",

--- a/packages/repixe-rekurke/CHANGELOG.md
+++ b/packages/repixe-rekurke/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.1.0 (2024-09-08)
+
+* docs: fix typo in package readme (#326) ([bce09dc](https://github.com/RShirohara/unified-webnovel/commit/bce09dc)), closes [#326](https://github.com/RShirohara/unified-webnovel/issues/326)
+* refactor: remove location info in convert process (#325) ([3b34f83](https://github.com/RShirohara/unified-webnovel/commit/3b34f83)), closes [#325](https://github.com/RShirohara/unified-webnovel/issues/325)
+* build(deps): bump vfile from 6.0.2 to 6.0.3 (#323) ([2842efb](https://github.com/RShirohara/unified-webnovel/commit/2842efb)), closes [#323](https://github.com/RShirohara/unified-webnovel/issues/323)
+* feat: add package `repixe-rekurke` (#317) ([7aadddb](https://github.com/RShirohara/unified-webnovel/commit/7aadddb)), closes [#317](https://github.com/RShirohara/unified-webnovel/issues/317)

--- a/packages/repixe-rekurke/package.json
+++ b/packages/repixe-rekurke/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rshirohara/repixe-rekurke",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0",
   "description": "repixe plugin that turns pixiv novel format into kakuyomu novel format to support rekurke.",
   "keywords": ["unified", "repixe", "pixiv", "rekurke", "kakuyomu"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/repixe-rekurke#readme",
@@ -33,9 +33,9 @@
     "vfile": "^6.0.3"
   },
   "devDependencies": {
+    "@rshirohara/rekurke-stringify": "workspace:*",
     "@rshirohara/repixe-parse": "workspace:*",
     "@rshirohara/repixe-stringify": "workspace:*",
-    "@rshirohara/rekurke-stringify": "workspace:*",
     "@unified-webnovel/tsconfig": "workspace:*"
   },
   "publishConfig": {

--- a/packages/repixe-stringify/CHANGELOG.md
+++ b/packages/repixe-stringify/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.4](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-stringify@0.2.3...@rshirohara/repixe-stringify@0.2.4) (2024-09-08)
+
+* build(deps): bump unified from 11.0.4 to 11.0.5 (#308) ([2c675ee](https://github.com/RShirohara/unified-webnovel/commit/2c675ee)), closes [#308](https://github.com/RShirohara/unified-webnovel/issues/308)
+
 ## [0.2.3](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-stringify@0.2.2...@rshirohara/repixe-stringify@0.2.3) (2024-04-14)
 
 ### Documents

--- a/packages/repixe-stringify/package.json
+++ b/packages/repixe-stringify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rshirohara/repixe-stringify",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "repixe plugin to add support for serializing pixiv novel format.",
   "keywords": ["unified", "repixe", "pixiv"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/repixe-stringify#readme",

--- a/packages/repixe/CHANGELOG.md
+++ b/packages/repixe/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.4](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe@0.2.3...@rshirohara/repixe@0.2.4) (2024-09-08)
+
+* build(deps): bump unified from 11.0.4 to 11.0.5 (#308) ([2c675ee](https://github.com/RShirohara/unified-webnovel/commit/2c675ee)), closes [#308](https://github.com/RShirohara/unified-webnovel/issues/308)
+
 ## [0.2.3](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe@0.2.2...@rshirohara/repixe@0.2.3) (2024-04-14)
 
 **Note:** Version bump only for package @rshirohara/repixe

--- a/packages/repixe/package.json
+++ b/packages/repixe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rshirohara/repixe",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "unified processor with support for parsing and serializing pixiv novel format input/output.",
   "keywords": ["unified", "repixe", "pixiv"],
   "homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/repixe#readme",


### PR DESCRIPTION
- `@rshirohara/kkast`: `0.1.1` -> `0.1.2`
- `@rshirohara/pxast`: `0.2.2` -> `0.2.3`
- `@rshirohara/rekurke`: `0.1.1` -> `0.1.2`
- `@rshirohara/rekurke-parse`: `0.1.0` -> `0.1.1`
- `@rshirohara/rekurke-repixe`: `0.1.0`
- `@rshirohara/rekurke-stringify`: `0.1.1` -> `0.1.2`
- `@rshirohara/repixe`: `0.2.3` -> `0.2.4`
- `@rshirohara/repixe-parse`: `0.2.3` -> `0.2.4`
- `@rshirohara/repixe-rekurke`: `0.1.0`
- `@rshirohara/repixe-stringify`: `0.2.3` -> `0.2.4`