### PR TITLE
refactor: replace `PageHeading` to `PageBreak` on forgot to delete location

### DIFF
--- a/packages/repixe-rekurke/test/ast.test.ts
+++ b/packages/repixe-rekurke/test/ast.test.ts
@@ -48,7 +48,7 @@ describe("FlowContent", () => {
   });
 
   describe("pageBreak", () => {
-    test("preserveUnmatchedSyntax が false の場合、PageHeading は削除される。", () => {
+    test("preserveUnmatchedSyntax が false の場合、PageBreak は削除される。", () => {
       const source: PxastRoot = {
         type: "root",
         children: [{ type: "pageBreak" }],

--- a/packages/repixe-stringify/README.md
+++ b/packages/repixe-stringify/README.md
@@ -46,7 +46,6 @@ async function main() {
   const source = {
     type: "root",
     children: [
-      { type: "pageHeading", pageNumber: 1 },
       {
         type: "paragraph",
         children: [
@@ -79,7 +78,7 @@ async function main() {
           { type: "text", value: "も使える。" }
         ]
       },
-      { type: "pageHeading", pageNumber: 2 },
+      { type: "pageBreak" },
       {
         type: "paragraph",
         children: [

--- a/packages/repixe-stringify/src/lib/index.ts
+++ b/packages/repixe-stringify/src/lib/index.ts
@@ -25,7 +25,7 @@ function compileContent(nodes: PxastContent[]): string[] {
         return compilers.heading.compile({ node });
       }
       case "pageBreak": {
-        return compilers.pageHeading.compile({ node });
+        return compilers.pageBreak.compile({ node });
       }
       case "paragraph": {
         return compilers.paragraph.compile({ node });
@@ -67,7 +67,7 @@ const compilers = {
     },
   } as NodeCompiler<Heading>,
 
-  pageHeading: {
+  pageBreak: {
     compile: (_) => {
       return "[newpage]";
     },


### PR DESCRIPTION
Replace `PageHeading` to `PageBreak` on forgot to delete location in #329.