### PR TITLE
refactor: fix biome check warnings

### DIFF
--- a/packages/rekurke-parse/src/lib/postprocessor.ts
+++ b/packages/rekurke-parse/src/lib/postprocessor.ts
@@ -24,7 +24,7 @@ function removeLastBreaks<T extends KkastNode>(node: T): T {
     }
     case "paragraph": {
       if (
-        node.children.length >= 1 &&
+        node.children.length > 0 &&
         node.children[node.children.length - 1].type === "break"
       ) {
         return { ...node, children: node.children.slice(0, -1) };

--- a/packages/rekurke-repixe/src/lib/converter.ts
+++ b/packages/rekurke-repixe/src/lib/converter.ts
@@ -43,6 +43,9 @@ export function convertRoot(
           case "break": {
             return convertBreak(node, options);
           }
+          default: {
+            return undefined;
+          }
         }
       })
       .filter((node) => node !== undefined),
@@ -56,22 +59,27 @@ function convertParagraph(
 ): PxastParagraph {
   return {
     type: "paragraph",
-    children: [...tree.children].map((node) => {
-      switch (node.type) {
-        case "text": {
-          return convertText(node, options);
+    children: [...tree.children]
+      .map((node) => {
+        switch (node.type) {
+          case "text": {
+            return convertText(node, options);
+          }
+          case "ruby": {
+            return convertRuby(node, options);
+          }
+          case "emphasis": {
+            return convertEmphasis(node, options);
+          }
+          case "break": {
+            return convertBreak(node, options);
+          }
+          default: {
+            return undefined;
+          }
         }
-        case "ruby": {
-          return convertRuby(node, options);
-        }
-        case "emphasis": {
-          return convertEmphasis(node, options);
-        }
-        case "break": {
-          return convertBreak(node, options);
-        }
-      }
-    }),
+      })
+      .filter((node) => node !== undefined),
   };
 }
 


### PR DESCRIPTION
- Add default clause to switch statement in `rekurke-repixe`.
- Change node length check to 0-base in `rekurke-parse`.
