### PR TITLE
chore(deps-dev): pin dev-dependency version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,11 @@
     "rekurke",
     "repixe",
     "rshirohara",
-    "webnovel"
+    "webnovel",
+    "Shirohara",
+    "postpack",
+    "pegjs",
+    "tspegjs"
   ],
   "javascript.format.enable": false,
   "npm.packageManager": "pnpm"

--- a/package.json
+++ b/package.json
@@ -16,17 +16,17 @@
     "version:update": "lerna version --conventional-commits --no-git-tag-version --sync-workspace-lock"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
-    "@edge-runtime/vm": "^4.0.4",
-    "@lerna-lite/changed": "^3.10.1",
-    "@lerna-lite/cli": "^3.10.1",
-    "@lerna-lite/publish": "^3.10.1",
-    "@lerna-lite/version": "^3.10.1",
-    "@vitest/coverage-v8": "^2.1.6",
-    "clean-package": "^2.2.0",
-    "conventional-changelog-conventionalcommits": "^7.0.2",
-    "typescript": "^5.7.2",
-    "vite-tsconfig-paths": "^5.1.3",
-    "vitest": "^2.1.6"
+    "@biomejs/biome": "1.9.4",
+    "@edge-runtime/vm": "4.0.4",
+    "@lerna-lite/changed": "3.10.1",
+    "@lerna-lite/cli": "3.10.1",
+    "@lerna-lite/publish": "3.10.1",
+    "@lerna-lite/version": "3.10.1",
+    "@vitest/coverage-v8": "2.1.6",
+    "clean-package": "2.2.0",
+    "conventional-changelog-conventionalcommits": "7.0.2",
+    "typescript": "5.7.2",
+    "vite-tsconfig-paths": "5.1.3",
+    "vitest": "2.1.6"
   }
 }

--- a/packages/rekurke-parse/package.json
+++ b/packages/rekurke-parse/package.json
@@ -34,8 +34,8 @@
   },
   "devDependencies": {
     "@unified-webnovel/tsconfig": "workspace:*",
-    "peggy": "^4.2.0",
-    "ts-pegjs": "^4.2.1"
+    "peggy": "4.2.0",
+    "ts-pegjs": "4.2.1"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/repixe-parse/package.json
+++ b/packages/repixe-parse/package.json
@@ -34,8 +34,8 @@
   },
   "devDependencies": {
     "@unified-webnovel/tsconfig": "workspace:*",
-    "peggy": "^4.2.0",
-    "ts-pegjs": "^4.2.1"
+    "peggy": "4.2.0",
+    "ts-pegjs": "4.2.1"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@unified-webnovel/tsconfig",
-  "version": "0.0.0-local.4",
   "private": true,
   "description": "tsconfig.json definition for unified-webnovel.",
   "files": ["./tsconfig.*.json"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,40 +9,40 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: ^1.9.4
+        specifier: 1.9.4
         version: 1.9.4
       '@edge-runtime/vm':
-        specifier: ^4.0.4
+        specifier: 4.0.4
         version: 4.0.4
       '@lerna-lite/changed':
-        specifier: ^3.10.1
+        specifier: 3.10.1
         version: 3.10.1(@lerna-lite/publish@3.10.1(@types/node@22.7.4)(typescript@5.7.2))(@lerna-lite/version@3.10.1(@lerna-lite/publish@3.10.1(@types/node@22.7.4)(typescript@5.7.2))(@types/node@22.7.4)(typescript@5.7.2))(@types/node@22.7.4)(typescript@5.7.2)
       '@lerna-lite/cli':
-        specifier: ^3.10.1
+        specifier: 3.10.1
         version: 3.10.1(@lerna-lite/list@3.10.1(@lerna-lite/publish@3.10.1(@types/node@22.7.4)(typescript@5.7.2))(@lerna-lite/version@3.10.1(@lerna-lite/publish@3.10.1(@types/node@22.7.4)(typescript@5.7.2))(@types/node@22.7.4)(typescript@5.7.2))(@types/node@22.7.4)(typescript@5.7.2))(@lerna-lite/publish@3.10.1(@types/node@22.7.4)(typescript@5.7.2))(@lerna-lite/version@3.10.1(@lerna-lite/publish@3.10.1(@types/node@22.7.4)(typescript@5.7.2))(@types/node@22.7.4)(typescript@5.7.2))(@types/node@22.7.4)(typescript@5.7.2)
       '@lerna-lite/publish':
-        specifier: ^3.10.1
+        specifier: 3.10.1
         version: 3.10.1(@types/node@22.7.4)(typescript@5.7.2)
       '@lerna-lite/version':
-        specifier: ^3.10.1
+        specifier: 3.10.1
         version: 3.10.1(@lerna-lite/publish@3.10.1(@types/node@22.7.4)(typescript@5.7.2))(@types/node@22.7.4)(typescript@5.7.2)
       '@vitest/coverage-v8':
-        specifier: ^2.1.6
+        specifier: 2.1.6
         version: 2.1.6(vitest@2.1.6(@edge-runtime/vm@4.0.4)(@types/node@22.7.4))
       clean-package:
-        specifier: ^2.2.0
+        specifier: 2.2.0
         version: 2.2.0
       conventional-changelog-conventionalcommits:
-        specifier: ^7.0.2
+        specifier: 7.0.2
         version: 7.0.2
       typescript:
-        specifier: ^5.7.2
+        specifier: 5.7.2
         version: 5.7.2
       vite-tsconfig-paths:
-        specifier: ^5.1.3
+        specifier: 5.1.3
         version: 5.1.3(typescript@5.7.2)(vite@6.0.1(@types/node@22.7.4))
       vitest:
-        specifier: ^2.1.6
+        specifier: 2.1.6
         version: 2.1.6(@edge-runtime/vm@4.0.4)(@types/node@22.7.4)
 
   packages/kkast:
@@ -97,10 +97,10 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       peggy:
-        specifier: ^4.2.0
+        specifier: 4.2.0
         version: 4.2.0
       ts-pegjs:
-        specifier: ^4.2.1
+        specifier: 4.2.1
         version: 4.2.1(peggy@4.2.0)
 
   packages/rekurke-repixe:
@@ -176,10 +176,10 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       peggy:
-        specifier: ^4.2.0
+        specifier: 4.2.0
         version: 4.2.0
       ts-pegjs:
-        specifier: ^4.2.1
+        specifier: 4.2.1
         version: 4.2.1(peggy@4.2.0)
 
   packages/repixe-rekurke:


### PR DESCRIPTION
- Pin the dev-dependency version completely.
- Add cspell words to vscode setting.