### PR TITLE
chore: bump version

### DIFF
--- a/packages/kkast/CHANGELOG.md
+++ b/packages/kkast/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.4](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/kkast@0.1.3...@rshirohara/kkast@0.1.4) (2024-12-01)
+
+**Note:** Version bump only for package @rshirohara/kkast
+
 ## [0.1.3](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/kkast@0.1.2...@rshirohara/kkast@0.1.3) (2024-10-27)
 
 ### Documents

--- a/packages/kkast/package.json
+++ b/packages/kkast/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/kkast",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "Kakuyomu novel ast definition.",
 	"keywords": ["unified", "rekurke", "kakuyomu"],
 	"homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/kkast#readme",

--- a/packages/pxast/CHANGELOG.md
+++ b/packages/pxast/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.1](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/pxast@0.3.0...@rshirohara/pxast@0.3.1) (2024-12-01)
+
+**Note:** Version bump only for package @rshirohara/pxast
+
 ## [0.3.0](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/pxast@0.2.3...@rshirohara/pxast@0.3.0) (2024-10-27)
 
 ### ⚠ BREAKING CHANGES

--- a/packages/pxast/package.json
+++ b/packages/pxast/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/pxast",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "Pixiv novel ast definition.",
 	"keywords": ["unified", "repixe", "pixiv"],
 	"homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/pxast#readme",

--- a/packages/rekurke-parse/CHANGELOG.md
+++ b/packages/rekurke-parse/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.3](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke-parse@0.1.2...@rshirohara/rekurke-parse@0.1.3) (2024-12-01)
+
+### Build System
+
+* **deps-dev:** bump peggy from 4.0.3 to 4.1.1 in the peggy group ([#354](https://github.com/RShirohara/unified-webnovel/issues/354)) ([f02ff8e](https://github.com/RShirohara/unified-webnovel/commit/f02ff8e9591e59f64307695f4d274f3ce91b370a))
+* **deps-dev:** bump peggy from 4.1.1 to 4.2.0 in the peggy group ([#366](https://github.com/RShirohara/unified-webnovel/issues/366)) ([df606d0](https://github.com/RShirohara/unified-webnovel/commit/df606d0d73a868570d3d9a1b36c53ff1cd994d1d))
+
 ## [0.1.2](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke-parse@0.1.1...@rshirohara/rekurke-parse@0.1.2) (2024-10-27)
 
 ### Code Refactoring

--- a/packages/rekurke-parse/package.json
+++ b/packages/rekurke-parse/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/rekurke-parse",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "rekurke plugin to add support for parsing kakuyomu novel format.",
 	"keywords": ["unified", "rekurke", "kakuyomu"],
 	"homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/rekurke-parse#readme",

--- a/packages/rekurke-repixe/CHANGELOG.md
+++ b/packages/rekurke-repixe/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.2](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke-repixe@0.1.1...@rshirohara/rekurke-repixe@0.1.2) (2024-12-01)
+
+**Note:** Version bump only for package @rshirohara/rekurke-repixe
+
 ## [0.1.1](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke-repixe@0.1.0...@rshirohara/rekurke-repixe@0.1.1) (2024-10-27)
 
 ### Code Refactoring

--- a/packages/rekurke-repixe/package.json
+++ b/packages/rekurke-repixe/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/rekurke-repixe",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "rekurke plugin that turns kakuyomu novel format into pixiv novel format to support repixe.",
 	"keywords": ["unified", "rekurke", "kakuyomu", "repixe", "pixiv"],
 	"homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/rekurke-repixe#readme",

--- a/packages/rekurke-stringify/CHANGELOG.md
+++ b/packages/rekurke-stringify/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.4](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke-stringify@0.1.3...@rshirohara/rekurke-stringify@0.1.4) (2024-12-01)
+
+**Note:** Version bump only for package @rshirohara/rekurke-stringify
+
 ## [0.1.3](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke-stringify@0.1.2...@rshirohara/rekurke-stringify@0.1.3) (2024-10-27)
 
 **Note:** Version bump only for package @rshirohara/rekurke-stringify

--- a/packages/rekurke-stringify/package.json
+++ b/packages/rekurke-stringify/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/rekurke-stringify",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "rekurke plugin to add support for serializing kakuyomu novel format.",
 	"keywords": ["unified", "rekurke", "kakuyomu"],
 	"homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/rekurke-stringify#readme",

--- a/packages/rekurke/CHANGELOG.md
+++ b/packages/rekurke/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.4](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke@0.1.3...@rshirohara/rekurke@0.1.4) (2024-12-01)
+
+**Note:** Version bump only for package @rshirohara/rekurke
+
 ## [0.1.3](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke@0.1.2...@rshirohara/rekurke@0.1.3) (2024-10-27)
 
 **Note:** Version bump only for package @rshirohara/rekurke

--- a/packages/rekurke/package.json
+++ b/packages/rekurke/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/rekurke",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "unified processor with support for parsing and serializing kakuyomu novel format input/output.",
 	"keywords": ["unified", "rekurke", "kakuyomu"],
 	"homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/rekurke#readme",

--- a/packages/repixe-parse/CHANGELOG.md
+++ b/packages/repixe-parse/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.1](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-parse@0.3.0...@rshirohara/repixe-parse@0.3.1) (2024-12-01)
+
+### Build System
+
+* **deps-dev:** bump peggy from 4.0.3 to 4.1.1 in the peggy group ([#354](https://github.com/RShirohara/unified-webnovel/issues/354)) ([f02ff8e](https://github.com/RShirohara/unified-webnovel/commit/f02ff8e9591e59f64307695f4d274f3ce91b370a))
+* **deps-dev:** bump peggy from 4.1.1 to 4.2.0 in the peggy group ([#366](https://github.com/RShirohara/unified-webnovel/issues/366)) ([df606d0](https://github.com/RShirohara/unified-webnovel/commit/df606d0d73a868570d3d9a1b36c53ff1cd994d1d))
+
 ## [0.3.0](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-parse@0.2.4...@rshirohara/repixe-parse@0.3.0) (2024-10-27)
 
 ### ⚠ BREAKING CHANGES

--- a/packages/repixe-parse/package.json
+++ b/packages/repixe-parse/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/repixe-parse",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "repixe plugin to add support for parsing pixiv novel format.",
 	"keywords": ["unified", "repixe", "pixiv"],
 	"homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/repixe-parse#readme",

--- a/packages/repixe-rekurke/CHANGELOG.md
+++ b/packages/repixe-rekurke/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.1](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-rekurke@0.2.0...@rshirohara/repixe-rekurke@0.2.1) (2024-12-01)
+
+**Note:** Version bump only for package @rshirohara/repixe-rekurke
+
 ## [0.2.0](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-rekurke@0.1.0...@rshirohara/repixe-rekurke@0.2.0) (2024-10-27)
 
 ### ⚠ BREAKING CHANGES

--- a/packages/repixe-rekurke/package.json
+++ b/packages/repixe-rekurke/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/repixe-rekurke",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "repixe plugin that turns pixiv novel format into kakuyomu novel format to support rekurke.",
 	"keywords": ["unified", "repixe", "pixiv", "rekurke", "kakuyomu"],
 	"homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/repixe-rekurke#readme",

--- a/packages/repixe-stringify/CHANGELOG.md
+++ b/packages/repixe-stringify/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.1](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-stringify@0.3.0...@rshirohara/repixe-stringify@0.3.1) (2024-12-01)
+
+**Note:** Version bump only for package @rshirohara/repixe-stringify
+
 ## [0.3.0](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-stringify@0.2.4...@rshirohara/repixe-stringify@0.3.0) (2024-10-27)
 
 ### ⚠ BREAKING CHANGES

--- a/packages/repixe-stringify/package.json
+++ b/packages/repixe-stringify/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/repixe-stringify",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "repixe plugin to add support for serializing pixiv novel format.",
 	"keywords": ["unified", "repixe", "pixiv"],
 	"homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/repixe-stringify#readme",

--- a/packages/repixe/CHANGELOG.md
+++ b/packages/repixe/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.6](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe@0.2.5...@rshirohara/repixe@0.2.6) (2024-12-01)
+
+**Note:** Version bump only for package @rshirohara/repixe
+
 ## [0.2.5](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe@0.2.4...@rshirohara/repixe@0.2.5) (2024-10-27)
 
 ### Code Refactoring

--- a/packages/repixe/package.json
+++ b/packages/repixe/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/repixe",
-	"version": "0.2.5",
+	"version": "0.2.6",
 	"description": "unified processor with support for parsing and serializing pixiv novel format input/output.",
 	"keywords": ["unified", "repixe", "pixiv"],
 	"homepage": "https://github.com/RShirohara/unified-webnovel/tree/main/packages/repixe#readme",


### PR DESCRIPTION
- `@rshirohara/kkast`: 0.1.3 => 0.1.4
- `@rshirohara/pxast`: 0.3.0 => 0.3.1
- `@rshirohara/rekurke-parse`: 0.1.2 => 0.1.3
- `@rshirohara/rekurke-repixe`: 0.1.1 => 0.1.2
- `@rshirohara/rekurke-stringify`: 0.1.3 => 0.1.4
- `@rshirohara/rekurke`: 0.1.3 => 0.1.4
- `@rshirohara/repixe-parse`: 0.3.0 => 0.3.1
- `@rshirohara/repixe-rekurke`: 0.2.0 => 0.2.1
- `@rshirohara/repixe-stringify`: 0.3.0 => 0.3.1
- `@rshirohara/repixe`: 0.2.5 => 0.2.6