### PR TITLE
ci: maintenance actions

### DIFF
--- a/.github/actions/setup-pnpm/action.yaml
+++ b/.github/actions/setup-pnpm/action.yaml
@@ -29,7 +29,7 @@ runs:
         echo "STORE_PATH=$(pnpm store path)" >> ${GITHUB_OUTPUT}
 
     - name: Setup dependencies cache
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4.2.0
       with:
         path: ${{ steps.pnpm-config.outputs.STORE_PATH }}
         key: pnpm-cache-${{ inputs.cache-prefix }}-${{ hashFiles(format('{0}/pnpm-lock.yaml', inputs.cwd)) }}

--- a/.github/actions/setup-pnpm/action.yaml
+++ b/.github/actions/setup-pnpm/action.yaml
@@ -17,7 +17,7 @@ runs:
 
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v3.0.0
+      uses: pnpm/action-setup@v4.0.0
       with:
         run_install: false
 

--- a/.github/workflows/ci-package.yaml
+++ b/.github/workflows/ci-package.yaml
@@ -83,6 +83,10 @@ jobs:
             os: ubuntu-latest
             node-version: latest
             test-environment: node
+          - label: nodejs-22
+            os: ubuntu-latest
+            node-version: 20
+            test-environment: node
           - label: nodejs-20
             os: ubuntu-latest
             node-version: 20


### PR DESCRIPTION
- Bump `pnpm/action-setup` from 3.0.0 to 4.0.0.
- Bump `actions/cache` from 4.0.0 to 4.2.0.
- Add test environment `nodejs-22`.