### PR TITLE
chore(deps): add dependabot checking target

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -43,3 +43,16 @@ updates:
       - "RShirohara"
     reviewers:
       - "RShirohara"
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/setup-pnpm"
+    schedule:
+      interval: "monthly"
+      time: "03:00"
+      timezone: "Asia/Tokyo"
+    labels:
+      - "Type: CI"
+      - "Type: Dependencies"
+    assignees:
+      - "RShirohara"
+    reviewers:
+      - "RShirohara"


### PR DESCRIPTION
Add `/.github/actions/*` as a target for dependabot version checking.