### PR TITLE
chore: migrate deprecated `reviewers` option in dependabot configulation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* RShirohara@proton.me

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,8 +12,6 @@ updates:
       - "Type: Dependencies"
     assignees:
       - "RShirohara"
-    reviewers:
-      - "RShirohara"
     versioning-strategy: increase
     open-pull-requests-limit: 10
     groups:
@@ -42,6 +40,4 @@ updates:
       - "Type: CI"
       - "Type: Dependencies"
     assignees:
-      - "RShirohara"
-    reviewers:
       - "RShirohara"


### PR DESCRIPTION
Move deprecated `reviewers` option in dependabot configuration
to a method using `/.github/CODEOWNERS` file.