### PR TITLE
ci: remove support for Node.js EOL version

### DIFF
--- a/.github/workflows/ci-package.yaml
+++ b/.github/workflows/ci-package.yaml
@@ -85,11 +85,11 @@ jobs:
             test-environment: node
           - label: nodejs-24
             os: ubuntu-latest
-            node-version: 22
+            node-version: 24
             test-environment: node
           - label: nodejs-22
             os: ubuntu-latest
-            node-version: 20
+            node-version: 22
             test-environment: node
           - label: nodejs-20
             os: ubuntu-latest

--- a/.github/workflows/ci-package.yaml
+++ b/.github/workflows/ci-package.yaml
@@ -83,6 +83,10 @@ jobs:
             os: ubuntu-latest
             node-version: latest
             test-environment: node
+          - label: nodejs-24
+            os: ubuntu-latest
+            node-version: 22
+            test-environment: node
           - label: nodejs-22
             os: ubuntu-latest
             node-version: 20
@@ -90,10 +94,6 @@ jobs:
           - label: nodejs-20
             os: ubuntu-latest
             node-version: 20
-            test-environment: node
-          - label: nodejs-18
-            os: ubuntu-latest
-            node-version: 18
             test-environment: node
 
     permissions:

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "latest"
+pnpm = "latest"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "unified packages for web novel.",
 	"license": "MIT",
 	"type": "module",
-	"packageManager": "pnpm@9.14.4",
+	"packageManager": "pnpm@10.10.0",
 	"workspaces": ["./packages/*"],
 	"scripts": {
 		"build": "pnpm run -r build",


### PR DESCRIPTION
- Remove support for Node.js EOL version in test runner.
- Add mise config.
- Bump package manager `pnpm` version to `v10.10.0`.