### PR TITLE
chore: release packages

### DIFF
--- a/packages/kkast/CHANGELOG.md
+++ b/packages/kkast/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.5](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/kkast@0.1.4...@rshirohara/kkast@0.1.5) (2026-05-06)
+
+### Code Refactoring
+
+* apply linter/formatter upstream fixes ([#485](https://github.com/RShirohara/unified-webnovel/issues/485)) ([662e334](https://github.com/RShirohara/unified-webnovel/commit/662e3344c0aab970e7169ad1406a54ba55c60680))
+
 ## [0.1.4](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/kkast@0.1.3...@rshirohara/kkast@0.1.4) (2024-12-01)
 
 **Note:** Version bump only for package @rshirohara/kkast

--- a/packages/kkast/package.json
+++ b/packages/kkast/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/kkast",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"description": "Kakuyomu novel ast definition.",
 	"keywords": [
 		"unified",

--- a/packages/pxast/CHANGELOG.md
+++ b/packages/pxast/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.2](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/pxast@0.3.1...@rshirohara/pxast@0.3.2) (2026-05-06)
+
+### Code Refactoring
+
+* apply linter/formatter upstream fixes ([#485](https://github.com/RShirohara/unified-webnovel/issues/485)) ([662e334](https://github.com/RShirohara/unified-webnovel/commit/662e3344c0aab970e7169ad1406a54ba55c60680))
+
 ## [0.3.1](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/pxast@0.3.0...@rshirohara/pxast@0.3.1) (2024-12-01)
 
 **Note:** Version bump only for package @rshirohara/pxast

--- a/packages/pxast/package.json
+++ b/packages/pxast/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/pxast",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"description": "Pixiv novel ast definition.",
 	"keywords": [
 		"unified",

--- a/packages/rekurke-parse/CHANGELOG.md
+++ b/packages/rekurke-parse/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.6](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke-parse@0.1.5...@rshirohara/rekurke-parse@0.1.6) (2026-05-06)
+
+### Code Refactoring
+
+* apply linter/formatter upstream fixes ([#485](https://github.com/RShirohara/unified-webnovel/issues/485)) ([662e334](https://github.com/RShirohara/unified-webnovel/commit/662e3344c0aab970e7169ad1406a54ba55c60680))
+
+### Build System
+
+* **deps-dev:** bump peggy from 5.0.3 to 5.0.4 in the peggy group ([#431](https://github.com/RShirohara/unified-webnovel/issues/431)) ([8b63b9b](https://github.com/RShirohara/unified-webnovel/commit/8b63b9bbb5c20513ce19f29407628026011af6f1))
+* **deps-dev:** bump peggy from 5.0.4 to 5.0.5 in the peggy group ([#438](https://github.com/RShirohara/unified-webnovel/issues/438)) ([882725b](https://github.com/RShirohara/unified-webnovel/commit/882725b52082d0e9874c890ba0b187d052ddc74d))
+* **deps-dev:** bump peggy from 5.0.5 to 5.0.6 in the peggy group ([#447](https://github.com/RShirohara/unified-webnovel/issues/447)) ([3743730](https://github.com/RShirohara/unified-webnovel/commit/3743730fd3c23ed7122bdfac0363237d41e6e7b5))
+* **deps-dev:** bump peggy from 5.0.6 to 5.1.0 in the peggy group ([#504](https://github.com/RShirohara/unified-webnovel/issues/504)) ([5af24e6](https://github.com/RShirohara/unified-webnovel/commit/5af24e64a9cf96dd46c5199a9e2afaa6032c79fd))
+
 ## [0.1.5](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke-parse@0.1.4...@rshirohara/rekurke-parse@0.1.5) (2025-06-01)
 
 ### Build System

--- a/packages/rekurke-parse/package.json
+++ b/packages/rekurke-parse/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/rekurke-parse",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"description": "rekurke plugin to add support for parsing kakuyomu novel format.",
 	"keywords": [
 		"unified",

--- a/packages/rekurke-repixe/CHANGELOG.md
+++ b/packages/rekurke-repixe/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.5](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke-repixe@0.1.4...@rshirohara/rekurke-repixe@0.1.5) (2026-05-06)
+
+### Code Refactoring
+
+* apply linter/formatter upstream fixes ([#485](https://github.com/RShirohara/unified-webnovel/issues/485)) ([662e334](https://github.com/RShirohara/unified-webnovel/commit/662e3344c0aab970e7169ad1406a54ba55c60680))
+
 ## [0.1.4](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke-repixe@0.1.3...@rshirohara/rekurke-repixe@0.1.4) (2025-06-01)
 
 **Note:** Version bump only for package @rshirohara/rekurke-repixe

--- a/packages/rekurke-repixe/package.json
+++ b/packages/rekurke-repixe/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/rekurke-repixe",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"description": "rekurke plugin that turns kakuyomu novel format into pixiv novel format to support repixe.",
 	"keywords": [
 		"unified",

--- a/packages/rekurke-stringify/CHANGELOG.md
+++ b/packages/rekurke-stringify/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.6](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke-stringify@0.1.5...@rshirohara/rekurke-stringify@0.1.6) (2026-05-06)
+
+### Code Refactoring
+
+* apply linter/formatter upstream fixes ([#485](https://github.com/RShirohara/unified-webnovel/issues/485)) ([662e334](https://github.com/RShirohara/unified-webnovel/commit/662e3344c0aab970e7169ad1406a54ba55c60680))
+
 ## [0.1.5](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/rekurke-stringify@0.1.4...@rshirohara/rekurke-stringify@0.1.5) (2025-01-20)
 
 ### Documents

--- a/packages/rekurke-stringify/package.json
+++ b/packages/rekurke-stringify/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/rekurke-stringify",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"description": "rekurke plugin to add support for serializing kakuyomu novel format.",
 	"keywords": [
 		"unified",

--- a/packages/repixe-parse/CHANGELOG.md
+++ b/packages/repixe-parse/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.4](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-parse@0.3.3...@rshirohara/repixe-parse@0.3.4) (2026-05-06)
+
+### Code Refactoring
+
+* apply linter/formatter upstream fixes ([#485](https://github.com/RShirohara/unified-webnovel/issues/485)) ([662e334](https://github.com/RShirohara/unified-webnovel/commit/662e3344c0aab970e7169ad1406a54ba55c60680))
+
+### Build System
+
+* **deps-dev:** bump peggy from 5.0.3 to 5.0.4 in the peggy group ([#431](https://github.com/RShirohara/unified-webnovel/issues/431)) ([8b63b9b](https://github.com/RShirohara/unified-webnovel/commit/8b63b9bbb5c20513ce19f29407628026011af6f1))
+* **deps-dev:** bump peggy from 5.0.4 to 5.0.5 in the peggy group ([#438](https://github.com/RShirohara/unified-webnovel/issues/438)) ([882725b](https://github.com/RShirohara/unified-webnovel/commit/882725b52082d0e9874c890ba0b187d052ddc74d))
+* **deps-dev:** bump peggy from 5.0.5 to 5.0.6 in the peggy group ([#447](https://github.com/RShirohara/unified-webnovel/issues/447)) ([3743730](https://github.com/RShirohara/unified-webnovel/commit/3743730fd3c23ed7122bdfac0363237d41e6e7b5))
+* **deps-dev:** bump peggy from 5.0.6 to 5.1.0 in the peggy group ([#504](https://github.com/RShirohara/unified-webnovel/issues/504)) ([5af24e6](https://github.com/RShirohara/unified-webnovel/commit/5af24e64a9cf96dd46c5199a9e2afaa6032c79fd))
+
 ## [0.3.3](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-parse@0.3.2...@rshirohara/repixe-parse@0.3.3) (2025-06-01)
 
 ### Build System

--- a/packages/repixe-parse/package.json
+++ b/packages/repixe-parse/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/repixe-parse",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"description": "repixe plugin to add support for parsing pixiv novel format.",
 	"keywords": [
 		"unified",

--- a/packages/repixe-rekurke/CHANGELOG.md
+++ b/packages/repixe-rekurke/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.4](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-rekurke@0.2.3...@rshirohara/repixe-rekurke@0.2.4) (2026-05-06)
+
+### Code Refactoring
+
+* apply linter/formatter upstream fixes ([#485](https://github.com/RShirohara/unified-webnovel/issues/485)) ([662e334](https://github.com/RShirohara/unified-webnovel/commit/662e3344c0aab970e7169ad1406a54ba55c60680))
+
 ## [0.2.3](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-rekurke@0.2.2...@rshirohara/repixe-rekurke@0.2.3) (2025-06-01)
 
 **Note:** Version bump only for package @rshirohara/repixe-rekurke

--- a/packages/repixe-rekurke/package.json
+++ b/packages/repixe-rekurke/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/repixe-rekurke",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"description": "repixe plugin that turns pixiv novel format into kakuyomu novel format to support rekurke.",
 	"keywords": [
 		"unified",

--- a/packages/repixe-stringify/CHANGELOG.md
+++ b/packages/repixe-stringify/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.3](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-stringify@0.3.2...@rshirohara/repixe-stringify@0.3.3) (2026-05-06)
+
+### Code Refactoring
+
+* apply linter/formatter upstream fixes ([#485](https://github.com/RShirohara/unified-webnovel/issues/485)) ([662e334](https://github.com/RShirohara/unified-webnovel/commit/662e3344c0aab970e7169ad1406a54ba55c60680))
+
 ## [0.3.2](https://github.com/RShirohara/unified-webnovel/compare/@rshirohara/repixe-stringify@0.3.1...@rshirohara/repixe-stringify@0.3.2) (2025-01-20)
 
 ### Documents

--- a/packages/repixe-stringify/package.json
+++ b/packages/repixe-stringify/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rshirohara/repixe-stringify",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"description": "repixe plugin to add support for serializing pixiv novel format.",
 	"keywords": [
 		"unified",


### PR DESCRIPTION
- `@rshirohara/kkast`: `0.1.4` -> `0.1.5`
- `@rshirohara/pxast`: `0.3.1` -> `0.3.2`
- `@rshirohara/rekurke-parse`: `0.1.5` -> `0.1.6`
- `@rshirohara/rekurke-repixe`: `0.1.4` -> `0.1.5`
- `@rshirohara/rekurke-stringify`: `0.1.5` -> `0.1.6`
- `@rshirohara/repixe-parse`: `0.3.3` -> `0.3.4`
- `@rshirohara/repixe-rekurke`: `0.2.3` -> `0.2.4`
- `@rshirohara/repixe-stringify`: `0.3.2` -> `0.3.3`